### PR TITLE
Use String instead of DataModel in GET queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ artists.forEach( (artist){
  List<AlbumInfo> albumList = await audioQuery.getAlbums();
 
 /// getting all albums available from a specific artist
-List<AlbumInfo> albums = await audioQuery.getAlbumsFromArtist(artist: artist);
+List<AlbumInfo> albums = await audioQuery.getAlbumsFromArtist(artist: artist.name);
     albums.forEach( (artistAlbum) {
       print(artistAlbum); //print all album property values
     });
@@ -89,13 +89,13 @@ List<AlbumInfo> albums = await audioQuery.getAlbumsFromArtist(artist: artist);
 
  genreList.foreach( (genre){
    /// getting all artists available from specific genre.
-   await audioQuery.getArtistsFromGenre(genre: genre);
+   await audioQuery.getArtistsFromGenre(genre: genre.name);
 
    /// getting all albums which appears on genre [genre].
-   await audioQuery.getAlbumsFromGenre(genre: genre);
+   await audioQuery.getAlbumsFromGenre(genre: genre.name);
 
    /// getting all songs which appears on genre [genre]
-   await audioQuery.getSongsFromGenre(genre: genre);
+   await audioQuery.getSongsFromGenre(genre: genre.name);
  } );
  ```
  ### Getting songs data
@@ -105,7 +105,7 @@ List<SongInfo> songs = await audioQuery.getSongs();
 
 albumList.foreach( (album){
   /// getting songs from specific album
-  audioQuery.getSongsFromAlbum(album: album);
+  audioQuery.getSongsFromAlbum(album: album.name);
  } );
 ```
 

--- a/lib/src/flutter_audio_query.dart
+++ b/lib/src/flutter_audio_query.dart
@@ -118,11 +118,11 @@ class FlutterAudioQuery {
   ///
   /// [genre] Genre that we want fetch albums. Genre must not be null.
   Future<List<AlbumInfo>> getAlbumsFromGenre(
-      {@required final GenreInfo genre,
+      {@required final String genre,
       AlbumSortType sortType = AlbumSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod('getAlbumsFromGenre', {
       SOURCE_KEY: SOURCE_ALBUM,
-      'genre_name': genre.name,
+      'genre_name': genre,
       SORT_TYPE: sortType.index,
     });
     return _parseAlbumDataList(dataList);
@@ -132,10 +132,10 @@ class FlutterAudioQuery {
   ///
   /// [artist] must be non null.
   Future<List<AlbumInfo>> getAlbumsFromArtist(
-      {@required final ArtistInfo artist,
+      {@required final String artist,
       AlbumSortType sortType = AlbumSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod('getAlbumsFromArtist', {
-      'artist': artist.name,
+      'artist': artist,
       SOURCE_KEY: SOURCE_ALBUM,
       SORT_TYPE: sortType.index,
     });
@@ -171,10 +171,10 @@ class FlutterAudioQuery {
   ///
   /// [artist] must be non null
   Future<List<SongInfo>> getSongsFromArtist(
-      {@required final ArtistInfo artist,
+      {@required final String artist,
       SongSortType sortType = SongSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod("getSongsFromArtist", {
-      'artist': artist.name,
+      'artist': artist,
       SOURCE_KEY: SOURCE_SONGS,
       SORT_TYPE: sortType.index,
     });
@@ -191,10 +191,10 @@ class FlutterAudioQuery {
   ///
   /// [album] Represents the album that we want to fetch all songs. Must be non null.
   Future<List<SongInfo>> getSongsFromAlbum(
-      {@required final AlbumInfo album,
+      {@required final String albumId,
       SongSortType sortType = SongSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod("getSongsFromAlbum", {
-      'album_id': album.id,
+      'album_id': albumId,
       SOURCE_KEY: SOURCE_SONGS,
       SORT_TYPE: sortType.index,
     });
@@ -210,13 +210,13 @@ class FlutterAudioQuery {
   /// [artist] The artist which that appears on [album]. Must be non null.
   /// [album] The album. Must be non null.
   Future<List<SongInfo>> getSongsFromArtistAlbum(
-      {@required final AlbumInfo album,
-      @required final ArtistInfo artist,
+      {@required final String albumId,
+      @required final String artist,
       SongSortType sortType = SongSortType.DEFAULT}) async {
     List<dynamic> dataList =
         await channel.invokeMethod("getSongsFromArtistAlbum", {
-      'album_id': album.id,
-      'artist': artist.name,
+      'album_id': albumId,
+      'artist': artist,
       SOURCE_KEY: SOURCE_SONGS,
       SORT_TYPE: sortType.index,
     });
@@ -228,11 +228,11 @@ class FlutterAudioQuery {
   ///
   /// [genre] must be non null.
   Future<List<SongInfo>> getSongsFromGenre(
-      {@required final GenreInfo genre,
+      {@required final String genre,
       SongSortType sortType = SongSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod("getSongsFromGenre", {
       SOURCE_KEY: SOURCE_SONGS,
-      'genre_name': genre.name,
+      'genre_name': genre,
       SORT_TYPE: sortType.index,
     });
     return _parseSongDataList(dataList);


### PR DESCRIPTION
Breaking change: TRUE

If it's not possible to created `DataModel` objects, we should be able to request eg. songs, artists, albums using String objects.