### PR TITLE
Fix album art issue on android 10

### DIFF
--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
@@ -32,6 +32,7 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 
 import boaventura.com.devel.br.flutteraudioquery.delegate.AudioQueryDelegate;
+import boaventura.com.devel.br.flutteraudioquery.loaders.cache.AlbumArtCache;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -80,6 +81,7 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
 
       final FlutterAudioQueryPlugin plugin = new FlutterAudioQueryPlugin();
       Log.i("AUDIO_QUERY", "Using V1 EMBEDDING");
+      Log.i("AUDIO_QUERY",AlbumArtCache.CAHCE_DIR);
       plugin.setup(registrar.messenger(), application, registrar.activity(), registrar, null);
   }
 
@@ -115,7 +117,6 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
                   result.error("unknown_source",
                               "method call was made by an unknown source", null);
                   break;
-
           }
       }
 
@@ -146,6 +147,7 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
                 null,
                 m_activityBinding
         );
+        AlbumArtCache.CAHCE_DIR = m_pluginBinding.getApplicationContext().getCacheDir().getAbsolutePath();
   }
 
   @Override

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ArtistLoader.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ArtistLoader.java
@@ -3,6 +3,7 @@ package boaventura.com.devel.br.flutteraudioquery.loaders;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.util.Log;
 
@@ -11,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import boaventura.com.devel.br.flutteraudioquery.loaders.cache.AlbumArtCache;
 import boaventura.com.devel.br.flutteraudioquery.loaders.tasks.AbstractLoadTask;
 import boaventura.com.devel.br.flutteraudioquery.sortingtypes.ArtistSortType;
 import io.flutter.plugin.common.EventChannel;
@@ -381,7 +383,8 @@ public class ArtistLoader extends AbstractLoader {
             Cursor artworkCursor = m_resolver.query(
                     MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
                     new String[]{
-                            MediaStore.Audio.AlbumColumns.ALBUM_ART,
+                            MediaStore.Audio.Albums._ID,
+                            MediaStore.Audio.Albums.ALBUM_ART,
                             MediaStore.Audio.AlbumColumns.ARTIST
                     },
 
@@ -393,9 +396,19 @@ public class ArtistLoader extends AbstractLoader {
                 //Log.i(TAG, "total paths " + artworkCursor.getCount());
                     while (artworkCursor.moveToNext()) {
                         try {
-                            artworkPath = artworkCursor.getString(
-                                    artworkCursor.getColumnIndex(MediaStore.Audio.Albums.ALBUM_ART)
-                            );
+
+                            if (Build.VERSION.SDK_INT >=29){
+                                String albumId = artworkCursor.getString(
+                                        artworkCursor.getColumnIndex(MediaStore.Audio.Albums._ID));
+                                Log.i("ArtistLoader",albumId);
+
+                                int id = Integer.parseInt(albumId);
+                                artworkPath = AlbumArtCache.getInstance().getPathForAlbum(id);
+                            } else {
+                                artworkPath = artworkCursor.getString(
+                                        artworkCursor.getColumnIndex(MediaStore.Audio.Albums.ALBUM_ART)
+                                );
+                            }
 
                             // breaks in first valid path founded.
                             if (artworkPath != null)

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/SongLoader.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/SongLoader.java
@@ -524,7 +524,7 @@ public class SongLoader extends AbstractLoader {
 
             String artPath = null;
 
-            if (artCursor !=null){
+            if (artCursor !=null && artCursor.moveToFirst()){
                 while (artCursor.moveToNext()) {
 
                     try {

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/SongLoader.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/SongLoader.java
@@ -511,7 +511,7 @@ public class SongLoader extends AbstractLoader {
          */
         private String getAlbumArtPathForSong(String album) {
             Log.i("AlbumLoader", album);
-            if (Build.VERSION.SDK_INT >=29){
+            if (Build.VERSION.SDK_INT >= 29) {
                 int id = Integer.parseInt(album);
                 return AlbumArtCache.getInstance().getPathForAlbum(id);
             }
@@ -525,17 +525,22 @@ public class SongLoader extends AbstractLoader {
             String artPath = null;
 
             if (artCursor != null && artCursor.moveToFirst()) {
-                while (artCursor.moveToNext()) {
+                do {
 
                     try {
 
                         artPath = artCursor.getString(artCursor.getColumnIndex(SONG_ALBUM_PROJECTION[1]));
+                        Log.i(TAG, artPath);
+                        if (artPath != null && !artPath.isEmpty()) {
+                            artCursor.close();
+                            return artPath;
+                        }
 
                     } catch (Exception ex) {
                         Log.e(TAG_ERROR, "SongLoader::getAlbumArtPathForSong method exception");
                         Log.e(TAG_ERROR, ex.getMessage());
                     }
-                }
+                } while ((artCursor.moveToNext()));
 
                 artCursor.close();
             }

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/cache/AlbumArtCache.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/cache/AlbumArtCache.java
@@ -1,0 +1,97 @@
+package boaventura.com.devel.br.flutteraudioquery.loaders.cache;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.net.Uri;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AlbumArtCache {
+    private static final String ALBUM_DIR = "albums";
+    private static AlbumArtCache instance;
+
+    public static String CAHCE_DIR = "";
+
+    public static AlbumArtCache getInstance() {
+        if (instance == null) {
+            instance = new AlbumArtCache();
+        }
+        return instance;
+    }
+
+    private AlbumArtCache() {
+    }
+
+    public String getPathForAlbum(int albumId) {
+        String path = Uri.parse(CAHCE_DIR).buildUpon()
+                .appendPath(ALBUM_DIR)
+                .build().toString();
+        path += "/" + albumId + ".jpg";
+        return path;
+    }
+
+    public String saveAlbumImage(ContentResolver resolver, int albumId) {
+        Uri sArtworkUri = Uri
+                .parse("content://media/external/audio/albumart");
+        Uri albumArtUri = ContentUris.withAppendedId(sArtworkUri, albumId);
+
+        try {
+            InputStream inputStream = resolver.openInputStream(albumArtUri);
+            File file = createFileForId(albumId);
+            file.createNewFile();
+            writeStreamToFile(inputStream, file);
+            return file.getAbsolutePath();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private void writeStreamToFile(InputStream inputStream, File file)
+            throws IOException {
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        while (inputStream.available() > 0) {
+            fileOutputStream.write(inputStream.read());
+        }
+        fileOutputStream.close();
+        inputStream.close();
+    }
+
+    private File createFileForId(int albumId) {
+
+        createAlbumsDirectory();
+        String path = Uri.parse(CAHCE_DIR).buildUpon().appendPath(ALBUM_DIR)
+                .build().toString();
+        path += "/" + albumId + ".jpg";
+        File file = new File(path);
+
+        if (file.exists()) {
+            file.delete();
+        }
+        return file;
+    }
+
+    private void createAlbumsDirectory() {
+        String path = Uri.parse(CAHCE_DIR).buildUpon().appendPath(ALBUM_DIR).build().toString();
+
+        File file = new File(path);
+
+        if (file.exists()) {
+            return;
+        }
+
+        file.mkdirs();
+    }
+
+    public boolean artExists(int albumId) {
+        String path = getPathForAlbum(albumId);
+        File file = new File(path);
+        return file.exists();
+    }
+}

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/tasks/SaveImageTask.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/tasks/SaveImageTask.java
@@ -1,0 +1,21 @@
+package boaventura.com.devel.br.flutteraudioquery.loaders.tasks;
+
+import android.content.ContentResolver;
+import android.os.AsyncTask;
+
+import boaventura.com.devel.br.flutteraudioquery.loaders.cache.AlbumArtCache;
+
+public class SaveImageTask extends AsyncTask<Void,Void,Void> {
+    ContentResolver resolver;
+    int albumId;
+    public SaveImageTask(ContentResolver resolver,int albumId){
+        this.resolver = resolver;
+        this.albumId = albumId;
+    }
+
+    @Override
+    protected Void doInBackground(Void... voids) {
+        AlbumArtCache.getInstance().saveAlbumImage(resolver,albumId);
+        return null;
+    }
+}


### PR DESCRIPTION
album_art has been deprecated starting from api 29 and have to call `contentResolver. loadThumbnail and get the bitmap.
the problem is, there is no way to send bitmap on method channel and get it in dart code.

solution is, saving every album art in cache and send file path of images from cache to dart code.

I've managed to do so but it requires an initialization process that takes long.

shayan4shayan@f9e2f46

there is a way to fix this. saving all of album arts in a single background thread and managing multiple images there.

but I don't know which one is better.

* right now I'm using AsyncTask to save the images but seems creation of multiple tasks cause methodChannel function calls be delayed til tasks finishing their job. because of that we need single background thread.