### PR TITLE
fixed issue #19

### DIFF
--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
@@ -202,17 +202,23 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
   }
 
   private void tearDown() {
-      m_activityBinding.removeRequestPermissionsResultListener(m_delegate);
-      m_activityBinding = null;
+      if(m_activityBinding != null){
+          m_activityBinding.removeRequestPermissionsResultListener(m_delegate);
+          m_activityBinding = null;
+      }
       if (lifecycle != null) {
           lifecycle.removeObserver(observer);
           lifecycle = null;
       }
       m_delegate = null;
-      channel.setMethodCallHandler(null);
-      channel = null;
-      application.unregisterActivityLifecycleCallbacks(observer);
-      application = null;
+      if (channel != null) {
+          channel.setMethodCallHandler(null);
+          channel = null;
+      }
+      if(application != null){
+          application.unregisterActivityLifecycleCallbacks(observer);
+          application = null;
+      }
     }
 
     private class LifeCycleObserver


### PR DESCRIPTION
Calling `removeRequestPermissionsResultListener()`, `setMethodCallHandler`, and `unregisterActivityLifecycleCallbacks` before checking weather `m_activityBinding`, `channel`, and `application` are null or not cause the plugin to crash. 