### PR TITLE
Feature/get artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5+2
+ * Support loading artwork on Android >= Q with getArtwork method
+ 
+
 ## 0.3.4+2  
 * Support V2 embedding Flutter API.
 * Fixing accept permission bug when using V2 Embedding Flutter API.  

--- a/README.md
+++ b/README.md
@@ -82,6 +82,52 @@ List<AlbumInfo> albums = await audioQuery.getAlbumsFromArtist(artist: artist.nam
       print(artistAlbum); //print all album property values
     });
 ```
+
+#### Getting artwork on Android >= Q:
+Since Android API level 29 ALBUM_ART constant is deprecated and plus
+scoped storage approach we can't load artwork from absolute image path.
+So if your app is running over Android API >= 29 you will get all artwork fields with null. To fetch images on these API levels you can use getArwork method.
+ 
+```dart
+ /// detecting, loading and displaying an artist artwork.
+ 
+ ArtistInfo artist // assuming a non null instance
+
+ // check if artistArtPath isn't available.
+
+ (artist.artistArtPath == null)
+
+    ? FutureBuilder<Uint8List>(
+      future: audioQuery.getArtwork(
+
+        type: ResourceType.ARTIST, id: artist.id),
+        builder: (_, snapshot) {
+          if (snapshot.data == null)
+            return Container(
+              height: 250.0,
+              child: Center(
+                child: CircularProgressIndicator(),
+              ),
+            );
+            
+            return CardItemWidget(
+              height: 250.0,
+              title: artist.name,
+              subtitle: "Number of Albums: ${artist.numberOfAlbums}",
+              infoText: "Number of Songs: ${artist.numberOfTracks}",
+              // The image bytes
+              // You can use Image.memory widget constructor 
+              // or MemoryImage image provider class to load image from bytes
+              // or a different approach.
+              rawImage: snapshot.data,
+            );
+          }) :
+          // or you can load image from File path if available.
+          Image.file( File( artist.artistArtPath ) )
+
+```
+
+
 ### Getting genre data
 ```dart
 /// getting all genres available

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
@@ -36,7 +36,7 @@ android {
 
 dependencies {
     api 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.core:core:1.2.0'
+    implementation 'androidx.core:core:1.3.1'
     implementation 'androidx.annotation:annotation:1.1.0'
 
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 02 19:57:50 BRT 2020
+#Sun Aug 02 19:15:47 BRT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
@@ -58,7 +58,7 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
 
 
 
-  // This is null when not using v2 embedding;
+  // These are null when not using v2 embedding;
   private Lifecycle lifecycle;
   private LifeCycleObserver observer;
 
@@ -109,6 +109,11 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
 
               case "playlist":
                   m_delegate.playlistSourceHandler(call, result);
+                  break;
+
+
+              case "artwork":
+                  m_delegate.artworkSourceHandler(call, result);
                   break;
 
               default:

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/FlutterAudioQueryPlugin.java
@@ -202,17 +202,23 @@ public class FlutterAudioQueryPlugin implements MethodCallHandler, FlutterPlugin
   }
 
   private void tearDown() {
-      m_activityBinding.removeRequestPermissionsResultListener(m_delegate);
-      m_activityBinding = null;
+      if(m_activityBinding != null){
+          m_activityBinding.removeRequestPermissionsResultListener(m_delegate);
+          m_activityBinding = null;
+      }
       if (lifecycle != null) {
           lifecycle.removeObserver(observer);
           lifecycle = null;
       }
       m_delegate = null;
-      channel.setMethodCallHandler(null);
-      channel = null;
-      application.unregisterActivityLifecycleCallbacks(observer);
-      application = null;
+      if (channel != null) {
+          channel.setMethodCallHandler(null);
+          channel = null;
+      }
+      if(application != null){
+          application.unregisterActivityLifecycleCallbacks(observer);
+          application = null;
+      }
     }
 
     private class LifeCycleObserver

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ImageLoader.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ImageLoader.java
@@ -1,0 +1,192 @@
+package boaventura.com.devel.br.flutteraudioquery.loaders;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.util.Size;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import boaventura.com.devel.br.flutteraudioquery.loaders.tasks.AbstractLoadTask;
+import io.flutter.plugin.common.MethodChannel;
+
+
+enum ResourceType {ARTIST, ALBUM, SONG};
+
+public class ImageLoader extends AbstractLoader {
+    public ImageLoader(Context context) {
+        super(context);
+    }
+
+    public synchronized void searchArtworkBytes( final MethodChannel.Result result, final int resourceType,
+                                                 final String id, final Size size  ){
+        if (id == null || id.isEmpty()) {
+            result.error("NO_ID", "id is required", null);
+            return;
+        }
+
+        String[] args = null;
+        String selection = "";
+        String sortOrder = null;
+
+        switch (resourceType){
+            // artist
+            case 0:
+                selection = MediaStore.Audio.Media.ARTIST_ID + " = ? ";
+                args = new String[] {id};
+                break;
+
+            // album
+            case 1:
+                selection = MediaStore.Audio.Media.ALBUM_ID + " = ? ";
+                args = new String[] {id};
+                break;
+            // song
+            case 2:
+                selection = MediaStore.Audio.Media._ID + " = ? ";
+                args = new String[]{id};
+                break;
+        }
+        new ImageLoadTask(result, getContentResolver(), selection, args, sortOrder, resourceType, size ).execute();
+    }
+
+    @Override
+    protected ImageLoadTask createLoadTask(MethodChannel.Result result,
+                                              String selection, String[] selectionArgs, String sortOrder, int type) {
+        return null;
+    }
+
+    private static class ImageLoadTask extends AbstractLoadTask< Map<String,Object> > {
+        private MethodChannel.Result m_result;
+        private ContentResolver m_resolver;
+        private int m_queryType;
+        private Size size;
+        private static final String key = "image";
+
+
+        /**
+         *
+         * @param result
+         * @param m_resolver
+         * @param selection
+         * @param selectionArgs
+         * @param sortOrder
+         */
+        ImageLoadTask(MethodChannel.Result result, ContentResolver m_resolver, String selection,
+                     String[] selectionArgs, String sortOrder, int type, Size size){
+
+            super(selection, selectionArgs, sortOrder);
+            this.m_resolver = m_resolver;
+            this.m_result = result;
+            this.m_queryType = type;
+            this.size = size;
+        }
+
+        @Override
+        protected void onPostExecute(Map<String,Object> map)     {
+            super.onPostExecute(map);
+            m_result.success(map);
+            this.m_resolver = null;
+            this.m_result = null;
+        }
+
+        private Map<String,Object> findImage(Cursor cursor) {
+
+            Map<String, Object> map = new HashMap<>();
+
+
+            if (cursor != null){
+                while(cursor.moveToNext()){
+                    final Uri uri = ContentUris.appendId(
+                            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI.buildUpon(),
+                            cursor.getLong( cursor.getColumnIndex(MediaStore.Audio.Media._ID) ))
+                            .build();
+
+                    try {
+                        Bitmap bitmap = this.m_resolver.loadThumbnail(uri, this.size , null);
+                        map.put(key, getBitmapBytes(bitmap) );
+                        bitmap.recycle();
+                        break;
+                    }
+                    catch (IOException ex){
+                        Log.i("DBG_TEST", "A problem here " + ex.getMessage());
+                    }
+
+                }
+                Log.i("DBG_TEST", " END WHILE  " );
+            }
+
+            if (map.isEmpty())
+                map.put(key, null);
+
+            if (cursor != null)
+                cursor.close();
+            return map;
+        }
+
+        private byte[] getBitmapBytes(Bitmap bmp){
+            byte[] imageBytes = null;
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                bmp.compress(Bitmap.CompressFormat.JPEG, 100, baos);
+                imageBytes = baos.toByteArray();
+                baos.close();
+            } catch (Exception ex){
+                Log.i("DBG_TEST", "Problem closing the native stream");
+            }
+            //String encodedImage = android.util.Base64.encodeToString(imageBytes, Base64.DEFAULT);
+            return imageBytes;
+        }
+
+        @Override
+        protected Map<String,Object> loadData(
+                final String selection, final String [] selectionArgs,
+                final String sortOrder ){
+
+            Cursor cursor= null;
+
+                switch (m_queryType){
+                    // ARTIST OR ALBUM
+
+                    case 0:
+                    case 1:
+                        cursor = this.m_resolver.query(
+                                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                                new String[]{MediaStore.Audio.Media._ID}, selection, selectionArgs, sortOrder );
+                        break;
+
+                    // SONG
+                    case 2:
+                        Map<String, Object> map = new HashMap<>();
+                        final Uri uri = ContentUris.appendId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI.buildUpon(),
+                                Long.parseLong( selectionArgs[0] )).build();
+                        try {
+
+                            Bitmap bitmap = this.m_resolver.loadThumbnail(uri, size, null);
+                            map.put(key, getBitmapBytes(bitmap));
+                        }
+                        catch (IOException ex){
+                            Log.i("DBG", "Problem reading song image " + ex.toString());
+                        }
+
+                        if (map.isEmpty())
+                            map.put(key, null);
+
+                        break;
+                }
+
+                return findImage(cursor);
+        }
+
+
+    }
+}

--- a/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ImageLoader.java
+++ b/android/src/main/java/boaventura/com/devel/br/flutteraudioquery/loaders/ImageLoader.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.MediaStore;
 import android.util.Log;
 import android.util.Size;
@@ -18,9 +17,6 @@ import java.util.Map;
 
 import boaventura.com.devel.br.flutteraudioquery.loaders.tasks.AbstractLoadTask;
 import io.flutter.plugin.common.MethodChannel;
-
-
-enum ResourceType {ARTIST, ALBUM, SONG};
 
 public class ImageLoader extends AbstractLoader {
     public ImageLoader(Context context) {
@@ -99,6 +95,7 @@ public class ImageLoader extends AbstractLoader {
             this.m_result = null;
         }
 
+        // finds an image
         private Map<String,Object> findImage(Cursor cursor) {
 
             Map<String, Object> map = new HashMap<>();
@@ -133,6 +130,7 @@ public class ImageLoader extends AbstractLoader {
             return map;
         }
 
+        // extract bitmap raw bytes.
         private byte[] getBitmapBytes(Bitmap bmp){
             byte[] imageBytes = null;
             try {
@@ -170,18 +168,17 @@ public class ImageLoader extends AbstractLoader {
                         final Uri uri = ContentUris.appendId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI.buildUpon(),
                                 Long.parseLong( selectionArgs[0] )).build();
                         try {
-
                             Bitmap bitmap = this.m_resolver.loadThumbnail(uri, size, null);
                             map.put(key, getBitmapBytes(bitmap));
                         }
                         catch (IOException ex){
-                            Log.i("DBG", "Problem reading song image " + ex.toString());
+                            //Log.i("DBG", "Problem reading song image " + ex.toString());
                         }
 
                         if (map.isEmpty())
                             map.put(key, null);
 
-                        break;
+                        return map;
                 }
 
                 return findImage(cursor);

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 

--- a/example/lib/src/ui/widgets/AlbumGridWidget.dart
+++ b/example/lib/src/ui/widgets/AlbumGridWidget.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_audio_query/flutter_audio_query.dart';
 import './CardItemWidget.dart';
@@ -15,6 +17,7 @@ class AlbumGridWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final FlutterAudioQuery audioQuery = FlutterAudioQuery();
     return GridView.builder(
         shrinkWrap: true,
         padding: EdgeInsets.only(bottom: 16.0),
@@ -26,13 +29,37 @@ class AlbumGridWidget extends StatelessWidget {
 
           return Stack(
             children: <Widget>[
-              CardItemWidget(
-                height: 250.0,
-                title: album.title,
-                subtitle: "Number of Songs: ${album.numberOfSongs}",
-                infoText: ("Year: ${album.firstYear ?? album.lastYear ?? ""}"),
-                backgroundImage: album.albumArt,
-              ),
+              (album.albumArt == null)
+                  ? FutureBuilder<Uint8List>(
+                      future: audioQuery.getArtwork(
+                          type: ResourceType.ALBUM, id: album.id),
+                      builder: (_, snapshot) {
+                        if (snapshot.data == null)
+                          return Container(
+                            height: 250.0,
+                            child: Center(
+                              child: CircularProgressIndicator(),
+                            ),
+                          );
+
+                        return CardItemWidget(
+                          height: 250.0,
+                          title: album.title,
+                          subtitle: "Number of Songs: ${album.numberOfSongs}",
+                          infoText:
+                              ("Year: ${album.firstYear ?? album.lastYear ?? ""}"),
+                          rawImage: snapshot.data,
+                          //backgroundImage: album.albumArt,
+                        );
+                      })
+                  : CardItemWidget(
+                      height: 250.0,
+                      title: album.title,
+                      subtitle: "Number of Songs: ${album.numberOfSongs}",
+                      infoText:
+                          ("Year: ${album.firstYear ?? album.lastYear ?? ""}"),
+                      backgroundImage: album.albumArt,
+                    ),
               Positioned.fill(
                 child: Material(
                   color: Colors.transparent,

--- a/example/lib/src/ui/widgets/ArtistListWidget.dart
+++ b/example/lib/src/ui/widgets/ArtistListWidget.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_audio_query/flutter_audio_query.dart';
 import './CardItemWidget.dart';
@@ -19,11 +21,10 @@ class ArtistListWidget extends StatelessWidget {
         itemCount: artistList.length,
         itemBuilder: (context, index) {
           ArtistInfo artist = artistList[index];
-          print("Calling artwork");
           return Stack(
             children: <Widget>[
               (artist.artistArtPath == null)
-                  ? FutureBuilder(
+                  ? FutureBuilder<Uint8List>(
                       future: audioQuery.getArtwork(
                           type: ResourceType.ARTIST, id: artist.id),
                       builder: (_, snapshot) {

--- a/example/lib/src/ui/widgets/ArtistListWidget.dart
+++ b/example/lib/src/ui/widgets/ArtistListWidget.dart
@@ -12,21 +12,45 @@ class ArtistListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final FlutterAudioQuery audioQuery = FlutterAudioQuery();
     return ListView.builder(
         shrinkWrap: true,
         padding: EdgeInsets.only(bottom: 16.0),
         itemCount: artistList.length,
         itemBuilder: (context, index) {
           ArtistInfo artist = artistList[index];
+          print("Calling artwork");
           return Stack(
             children: <Widget>[
-              CardItemWidget(
-                height: 250.0,
-                title: "Artist: ${artist.name}",
-                subtitle: "Number of Albums: ${artist.numberOfAlbums}",
-                infoText: "Number of Songs: ${artist.numberOfTracks}",
-                backgroundImage: artist.artistArtPath,
-              ),
+              (artist.artistArtPath == null)
+                  ? FutureBuilder(
+                      future: audioQuery.getArtwork(
+                          type: ResourceType.ARTIST, id: artist.id),
+                      builder: (_, snapshot) {
+                        if (snapshot.data == null)
+                          return Container(
+                            height: 250.0,
+                            child: Center(
+                              child: CircularProgressIndicator(),
+                            ),
+                          );
+                        return CardItemWidget(
+                          height: 250.0,
+                          title: "Artist: ${artist.name}",
+                          subtitle:
+                              "Number of Albums: ${artist.numberOfAlbums}",
+                          infoText: "Number of Songs: ${artist.numberOfTracks}",
+                          backgroundImage: artist.artistArtPath,
+                          rawImage: snapshot.data,
+                        );
+                      })
+                  : CardItemWidget(
+                      height: 250.0,
+                      title: "Artist: ${artist.name}",
+                      subtitle: "Number of Albums: ${artist.numberOfAlbums}",
+                      infoText: "Number of Songs: ${artist.numberOfTracks}",
+                      backgroundImage: artist.artistArtPath,
+                    ),
               Positioned.fill(
                 child: Material(
                   color: Colors.transparent,

--- a/example/lib/src/ui/widgets/CardItemWidget.dart
+++ b/example/lib/src/ui/widgets/CardItemWidget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 class CardItemWidget extends StatelessWidget {
   final double width, height;
   final String backgroundImage, title, subtitle, infoText;
+  final List<int> rawImage;
   static const titleMaxLines = 2;
   static const titleTextStyle =
       TextStyle(fontWeight: FontWeight.w500, fontSize: 16.0);
@@ -13,19 +14,23 @@ class CardItemWidget extends StatelessWidget {
       this.height,
       this.backgroundImage,
       this.title = "Title",
+      this.rawImage,
       this.subtitle = "subtitle",
       this.infoText = "infotext"});
 
   @override
   Widget build(BuildContext context) {
+    final hasRawImage = !(rawImage == null || rawImage.isEmpty);
     final mainContainer = Container(
       width: width,
       height: height,
       decoration: BoxDecoration(
         image: DecorationImage(
-          image: (backgroundImage == null)
+          image: (backgroundImage == null && !hasRawImage)
               ? AssetImage("assets/no_cover.png")
-              : FileImage(File(backgroundImage)),
+              : (hasRawImage)
+                  ? MemoryImage(rawImage) // Image.memory(rawImage)
+                  : FileImage(File(backgroundImage)),
           fit: BoxFit.cover,
           alignment: AlignmentDirectional.center,
         ),

--- a/example/lib/src/ui/widgets/ListItemWidget.dart
+++ b/example/lib/src/ui/widgets/ListItemWidget.dart
@@ -13,20 +13,28 @@ class ListItemWidget extends StatelessWidget {
   final Widget title, subtitle;
   final Widget trailing;
   final OnTap onTap;
+  final Widget leading;
 
   ListItemWidget(
-      {this.title, this.subtitle, this.imagePath, this.trailing, this.onTap});
+      {this.title,
+      this.subtitle,
+      this.leading,
+      this.imagePath,
+      this.trailing,
+      this.onTap});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
         ListTile(
-          leading: CircleAvatar(
-            backgroundImage: (imagePath == null)
-                ? AssetImage("assets/no_cover.png")
-                : FileImage(File(imagePath)),
-          ),
+          leading: (this.leading == null)
+              ? CircleAvatar(
+                  backgroundImage: (imagePath == null)
+                      ? AssetImage("assets/no_cover.png")
+                      : FileImage(File(imagePath)),
+                )
+              : leading,
           onTap: onTap,
           title: title ?? Container(),
           subtitle: subtitle ?? Container(),

--- a/example/lib/src/ui/widgets/SongListWidget.dart
+++ b/example/lib/src/ui/widgets/SongListWidget.dart
@@ -90,8 +90,8 @@ class SongListWidget extends StatelessWidget {
               leading: (song.albumArtwork == null)
                   ? FutureBuilder<Uint8List>(
                       future: audioQuery.getArtwork(
-                          type: ResourceType.ALBUM,
-                          id: song.albumId,
+                          type: ResourceType.SONG,
+                          id: song.id,
                           size: Size(100, 100)),
                       builder: (_, snapshot) {
                         if (snapshot.data == null)
@@ -99,11 +99,15 @@ class SongListWidget extends StatelessWidget {
                             child: CircularProgressIndicator(),
                           );
 
+                        if (snapshot.data.isEmpty)
+                          return CircleAvatar(
+                            backgroundImage: AssetImage("assets/no_cover.png"),
+                          );
+
                         return CircleAvatar(
                           backgroundColor: Colors.transparent,
-                          child: Image.memory(
+                          backgroundImage: MemoryImage(
                             snapshot.data,
-                            fit: BoxFit.fill,
                           ),
                         );
                       })

--- a/example/lib/src/ui/widgets/SongListWidget.dart
+++ b/example/lib/src/ui/widgets/SongListWidget.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_audio_query/flutter_audio_query.dart';
 import '../../Utility.dart';
@@ -15,78 +17,97 @@ class SongListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
-
     return ListView.builder(
         itemCount: songList.length,
         itemBuilder: (context, songIndex) {
           SongInfo song = songList[songIndex];
           return ListItemWidget(
-            title: Text("${song.title}"),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: <Widget>[
-                Text("Artist: ${song.artist}"),
-                Text(
-                  "Duration: ${Utility.parseToMinutesSeconds(int.parse(song.duration))}",
-                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.w500),
-                ),
-              ],
-            ),
-            trailing: (addToPlaylistAction == true)
-                ? IconButton(
-                    icon: Icon(Icons.playlist_add),
-                    onPressed: () {
-                      showDialog(
-                          context: context,
-                          builder: (context) {
-                            return AlertDialog(
-                              title: Text(_dialogTitle),
-                              content: FutureBuilder<List<PlaylistInfo>>(
-                                  future: audioQuery.getPlaylists(),
-                                  builder: (context, snapshot) {
-                                    if (snapshot.hasError) {
-                                      print("has error");
-                                      return Utility.createDefaultInfoWidget(
-                                          Text("${snapshot.error}"));
-                                    }
+              title: Text("${song.title}"),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: <Widget>[
+                  Text("Artist: ${song.artist}"),
+                  Text(
+                    "Duration: ${Utility.parseToMinutesSeconds(int.parse(song.duration))}",
+                    style:
+                        TextStyle(fontSize: 14.0, fontWeight: FontWeight.w500),
+                  ),
+                ],
+              ),
+              trailing: (addToPlaylistAction == true)
+                  ? IconButton(
+                      icon: Icon(Icons.playlist_add),
+                      onPressed: () {
+                        showDialog(
+                            context: context,
+                            builder: (context) {
+                              return AlertDialog(
+                                title: Text(_dialogTitle),
+                                content: FutureBuilder<List<PlaylistInfo>>(
+                                    future: audioQuery.getPlaylists(),
+                                    builder: (context, snapshot) {
+                                      if (snapshot.hasError) {
+                                        print("has error");
+                                        return Utility.createDefaultInfoWidget(
+                                            Text("${snapshot.error}"));
+                                      }
 
-                                    if (snapshot.hasData) {
-                                      if (snapshot.data.isEmpty) {
-                                        print("is Empty");
-                                        return NoDataWidget(
-                                          title: "There is no playlists",
+                                      if (snapshot.hasData) {
+                                        if (snapshot.data.isEmpty) {
+                                          print("is Empty");
+                                          return NoDataWidget(
+                                            title: "There is no playlists",
+                                          );
+                                        }
+
+                                        return PlaylistDialogContent(
+                                          options: snapshot.data
+                                              .map((playlist) => playlist.name)
+                                              .toList(),
+                                          onSelected: (index) {
+                                            snapshot.data[index]
+                                                .addSong(song: song);
+                                            Navigator.pop(context);
+                                          },
                                         );
                                       }
 
-                                      return PlaylistDialogContent(
-                                        options: snapshot.data
-                                            .map((playlist) => playlist.name)
-                                            .toList(),
-                                        onSelected: (index) {
-                                          snapshot.data[index]
-                                              .addSong(song: song);
-                                          Navigator.pop(context);
-                                        },
-                                      );
-                                    }
+                                      print("has no data");
+                                      return Utility.createDefaultInfoWidget(
+                                          CircularProgressIndicator());
+                                    }),
+                              );
+                            });
+                      },
+                      tooltip: "add to playlist",
+                    )
+                  : Container(
+                      width: .0,
+                      height: .0,
+                    ),
+              imagePath: song.albumArtwork,
+              leading: (song.albumArtwork == null)
+                  ? FutureBuilder<Uint8List>(
+                      future: audioQuery.getArtwork(
+                          type: ResourceType.ALBUM,
+                          id: song.albumId,
+                          size: Size(100, 100)),
+                      builder: (_, snapshot) {
+                        if (snapshot.data == null)
+                          return CircleAvatar(
+                            child: CircularProgressIndicator(),
+                          );
 
-                                    print("has no data");
-                                    return Utility.createDefaultInfoWidget(
-                                        CircularProgressIndicator());
-                                  }),
-                            );
-                          });
-                    },
-                    tooltip: "add to playlist",
-                  )
-                : Container(
-                    width: .0,
-                    height: .0,
-                  ),
-            imagePath: song.albumArtwork,
-          );
+                        return CircleAvatar(
+                          backgroundColor: Colors.transparent,
+                          child: Image.memory(
+                            snapshot.data,
+                            fit: BoxFit.fill,
+                          ),
+                        );
+                      })
+                  : null);
         });
   }
 }

--- a/lib/flutter_audio_query.dart
+++ b/lib/flutter_audio_query.dart
@@ -22,7 +22,10 @@
 
 library flutter_audio_query;
 
+import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 part 'src/album_info.dart';

--- a/lib/src/flutter_audio_query.dart
+++ b/lib/src/flutter_audio_query.dart
@@ -32,6 +32,8 @@ enum PlayListMethodType {
   WRITE
 }
 
+enum ResourceType { ARTIST, ALBUM, SONG }
+
 /// This class provides an interface for access audio data info.
 class FlutterAudioQuery {
   static const String _CHANNEL_NAME =
@@ -45,6 +47,7 @@ class FlutterAudioQuery {
   static const String SOURCE_ALBUM = 'album';
   static const String SOURCE_SONGS = 'song';
   static const String SOURCE_GENRE = 'genre';
+  static const String SOURCE_ARTWORK = 'artwork';
   static const String SORT_TYPE = "sort_type";
   static const String PLAYLIST_METHOD_TYPE = "method_type";
   static const String SOURCE_PLAYLIST = 'playlist';
@@ -148,7 +151,6 @@ class FlutterAudioQuery {
   /// [artist] Artist name must be non null.
   Future<List<AlbumInfo>> getAlbumsFromArtist(
       {@required final String artist,
-
       AlbumSortType sortType = AlbumSortType.DEFAULT}) async {
     List<dynamic> dataList = await channel.invokeMethod('getAlbumsFromArtist', {
       'artist': artist,
@@ -351,6 +353,30 @@ class FlutterAudioQuery {
     });
 
     return _parsePlaylistsDataList(dataList);
+  }
+
+  /// This method should be used if you're on Android >= Q with scoped storage working.
+  ///
+  Future<Uint8List> getArtwork({
+    @required final ResourceType type,
+    @required final String id,
+    final Size size,
+  }) async {
+    assert(id != null && type != null);
+    final data = await channel.invokeMethod("getArtwork", {
+      SOURCE_KEY: SOURCE_ARTWORK,
+      "resource": type.index,
+      "id": id,
+      "width": size?.width?.round() ?? 250,
+      "height": size?.height?.round() ?? 250,
+    });
+
+    Map<String, dynamic> dataMap = Map<String, dynamic>.from(data);
+    if (dataMap["image"] != null) {
+      final imageBytes = Uint8List.fromList(List<int>.from(dataMap["image"]));
+      return imageBytes;
+    }
+    return Uint8List.fromList([]);
   }
 
   /// This method creates a new empty playlist named [playlistName].

--- a/lib/src/flutter_audio_query.dart
+++ b/lib/src/flutter_audio_query.dart
@@ -355,7 +355,18 @@ class FlutterAudioQuery {
     return _parsePlaylistsDataList(dataList);
   }
 
-  /// This method should be used if you're on Android >= Q with scoped storage working.
+  /// This method fetchs an artowrk for ARSTIS, ALBUM or SONG based on content id.
+  /// It must be used on Android >= Q as scoped storage does not allow load images
+  /// using absolute file path.
+  ///
+  /// It returns an Uint8List with the bitmap bytes or empty list if no image was found.
+  ///
+  /// [type] The resource type you want to fetch an image. The values can be:
+  /// ResourceType.ARTIST, ResourceType.ALBUM OR ResourceType.SONG. It must be non null.
+  ///
+  /// [id] The content id you want an artwork image.
+  ///
+  /// [size] The image dimensions. The default value is Size(250, 250)
   ///
   Future<Uint8List> getArtwork({
     @required final ResourceType type,


### PR DESCRIPTION

#### Getting artwork on Android >= Q:
Since Android API level 29 ALBUM_ART constant is deprecated and plus
scoped storage approach we can't load artwork from absolute image path.
So if your app is running over Android API >= 29 you will get all artwork fields with null. To fetch images on these API levels you can use getArwork method.
 
```dart
 /// detecting, loading and displaying an artist artwork.
 
 ArtistInfo artist // assuming a non null instance

 // check if artistArtPath isn't available.

 (artist.artistArtPath == null)

    ? FutureBuilder<Uint8List>(
      future: audioQuery.getArtwork(

        type: ResourceType.ARTIST, id: artist.id),
        builder: (_, snapshot) {
          if (snapshot.data == null)
            return Container(
              height: 250.0,
              child: Center(
                child: CircularProgressIndicator(),
              ),
            );
            
            return CardItemWidget(
              height: 250.0,
              title: artist.name,
              subtitle: "Number of Albums: ${artist.numberOfAlbums}",
              infoText: "Number of Songs: ${artist.numberOfTracks}",
              // The image bytes
              // You can use Image.memory widget constructor 
              // or MemoryImage image provider class to load image from bytes
              // or a different approach.
              rawImage: snapshot.data,
            );
          }) :
          // or you can load image from File path if available.
          Image.file( File( artist.artistArtPath ) )

```